### PR TITLE
Update about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -28,7 +28,7 @@ Ratizux by Blockcity. 使用 Markdown
 
 [Sinofine](https://sinofine.me)
 
-[寒晶雪的文档站](https://hanjingxue-boling.github.io/whiteboard/)
+[白杨的文档站](https://whiteboard-ui8.pages.dev/)
 
 [Carbyne](https://c-j.dev)
 


### PR DESCRIPTION
文档站的 GitHub page 已经废弃，当前可用的是 cloudflare page 镜像。